### PR TITLE
Make Exclusive locks interruptible by async exceptions

### DIFF
--- a/System/FileLock.hs
+++ b/System/FileLock.hs
@@ -20,6 +20,11 @@
 --
 -- Note on the implementation: currently the module uses flock(2) on non-Windows
 -- platforms, and LockFileEx on Windows.
+--
+-- On non-Windows platforms, @InterruptibleFFI@ being used in the implementation
+-- ensures that `Exclusive` lock calls (which issue blocking syscalls) can be
+-- correctly interrupted by async exceptions (e.g. functions like `timeout`).
+-- This has been tested on Linux.
 module System.FileLock
   ( FileLock
   , SharedExclusive(..)

--- a/System/FileLock/Internal/Flock.hsc
+++ b/System/FileLock/Internal/Flock.hsc
@@ -1,3 +1,5 @@
+{-# LANGUAGE InterruptibleFFI #-}
+
 module System.FileLock.Internal.Flock
 #ifndef USE_FLOCK
   () where
@@ -7,6 +9,7 @@ module System.FileLock.Internal.Flock
 #include <sys/file.h>
 
 import Control.Applicative
+import Control.Concurrent (yield)
 import qualified Control.Exception as E
 import Data.Bits
 import Foreign.C.Error
@@ -50,8 +53,12 @@ flock (Fd fd) exclusive block = do
       case () of
         _ | errno == eWOULDBLOCK
             -> return False -- already taken
-          | errno == eINTR
-            -> flock (Fd fd) exclusive block
+          | errno == eINTR -> do
+              -- If InterruptibleFFI interrupted the syscall with EINTR,
+              -- we need to give the accompanying Haskell exception a chance to bubble.
+              -- See also https://gitlab.haskell.org/ghc/ghc/issues/8684#note_142404.
+              E.interruptible yield
+              flock (Fd fd) exclusive block
           | otherwise -> throwErrno "flock"
   where
     modeOp = case exclusive of
@@ -61,7 +68,9 @@ flock (Fd fd) exclusive block = do
       True -> 0
       False -> #{const LOCK_NB}
 
-foreign import ccall "flock"
+-- `interruptible` so that async exceptions like `timeout` can stop it
+-- when used in blocking mode (without `LOCK_NB`).
+foreign import ccall interruptible "flock"
   c_flock :: CInt -> CInt -> IO CInt
 
 #endif /* USE_FLOCK */


### PR DESCRIPTION
Hi Akio,

this fixes #6, making this package useful in conjunction with `timeout` and `async`.

See added comments for details.

Greetings,
Niklas