### PR TITLE
unix-2.8 changes how openFd works.

### DIFF
--- a/System/FileLock/Internal/Flock.hsc
+++ b/System/FileLock/Internal/Flock.hsc
@@ -39,7 +39,11 @@ unlock fd = closeFd fd
 
 open :: FilePath -> IO Fd
 open path = do
+#if MIN_VERSION_unix(2,8,0)
+  fd <- openFd path WriteOnly defaultFileFlags
+#else
   fd <- openFd path WriteOnly (Just stdFileMode) defaultFileFlags
+#endif
   -- Ideally, we would open the file descriptor with CLOEXEC enabled, but since
   -- unix 2.8 hasn't been released yet and we want backwards compatibility with
   -- older releases, we set CLOEXEC after opening the file descriptor.  This


### PR DESCRIPTION
`unix-2.8.0.0` changes how `openFd` works. See https://github.com/haskell/unix/commit/c7d88b3612fdf74a7964a670d6e79128f97f46b0

Some CPP will be required to maintain compatibility with older versions of `unix`.